### PR TITLE
driver: ctrl_timeoutをモジュールパラメーターに追加

### DIFF
--- a/driver/px4_usb.c
+++ b/driver/px4_usb.c
@@ -84,7 +84,7 @@ static int px4_usb_init_bridge(struct device *dev, struct usb_device *usb_dev,
 	bus->dev = dev;
 	bus->type = ITEDTV_BUS_USB;
 	bus->usb.dev = usb_dev;
-	bus->usb.ctrl_timeout = 3000;
+	bus->usb.ctrl_timeout = px4_usb_params.ctrl_timeout;
 	bus->usb.streaming.urb_buffer_size = 188 * px4_usb_params.urb_max_packets;
 	bus->usb.streaming.urb_num = px4_usb_params.max_urbs;
 	bus->usb.streaming.no_dma = px4_usb_params.no_dma;

--- a/driver/px4_usb_params.c
+++ b/driver/px4_usb_params.c
@@ -11,11 +11,18 @@
 #include <linux/module.h>
 
 struct px4_usb_param_set px4_usb_params = {
+	.ctrl_timeout = 3000,
 	.xfer_packets = 816,
 	.urb_max_packets = 816,
 	.max_urbs = 6,
 	.no_dma = false
 };
+
+module_param_named(ctrl_timeout, px4_usb_params.ctrl_timeout,
+		   int, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+MODULE_PARM_DESC(ctrl_timeout,
+		 "Time in msecs to wait for the message to complete " \
+		 "before timing out (if 0 the wait is forever). (default: 3000)");
 
 module_param_named(xfer_packets, px4_usb_params.xfer_packets,
 		   uint, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);

--- a/driver/px4_usb_params.h
+++ b/driver/px4_usb_params.h
@@ -6,6 +6,7 @@
 #include <linux/types.h>
 
 struct px4_usb_param_set {
+	int ctrl_timeout;
 	unsigned int xfer_packets;
 	unsigned int urb_max_packets;
 	unsigned int max_urbs;


### PR DESCRIPTION
表題の通り，`ctrl_timeout`をモジュールパラメーターに追加する修正です．

### 背景

Linux Kernel 6.xで以下のようなエラーをよく目にするようになりました．

```
# dmesgより抜粋
it930x_ctrl_msg: operation failed. (cmd: 0x002b, ret: -110)
```

ここで`-110`は`ETIMEDOUT`です．

`tcpdump` + `usbmon`でusbでのやり取りを取得したところ，既定値の3000ms後に応答をちゃんと受信している場合があることが確認できました．遅延の原因はまだ不明ですが，それまでの対処療法として`ctrl_timeout`をモジュールパラメーターに追加しました．

以下を追加後，再起動．

```
# /etc/modprobe.d/px4_drv.conf
options px4_drv ctrl_timeout=5000 psb_purge_timeout=5000
```

ROCK64 + PX-W3U4上で動作しているmirakcによる４チャンネルのタイムシフト録画を行い４日経ちましたが，上記エラーは発生していません．
タイムアウト値は環境に依存するものと推測しますが，調整することによりエラーを回避できることが分かりました．

### 補足

`usb_bulk_msg`の詳細は https://manpages.debian.org/jessie-backports/linux-manual-4.8/usb_bulk_msg.9

mirakcの`onair-program-trackers`使用時に発生しているように見えることから，同一チューナーにて別チャンネルのストリームに短い時間間隔で切り替えると発生するのかもしれません．これは推測であり，詳細はまだ不明です．