### PR TITLE
driver: use of mdelay is discouraged

### DIFF
--- a/driver/itedtv_bus.c
+++ b/driver/itedtv_bus.c
@@ -58,7 +58,7 @@ static int itedtv_usb_ctrl_tx(struct itedtv_bus *bus, void *buf, int len)
 			   buf, len,
 			   &rlen, bus->usb.ctrl_timeout);
 
-	mdelay(1);
+	usleep_range(1000, 1100);
 
 	return ret;
 }
@@ -79,7 +79,7 @@ static int itedtv_usb_ctrl_rx(struct itedtv_bus *bus, void *buf, int *len)
 
 	*len = rlen;
 
-	mdelay(1);
+	usleep_range(1000, 1100);
 
 	return ret;
 }

--- a/driver/r850.c
+++ b/driver/r850.c
@@ -1008,7 +1008,7 @@ static int r850_read_adc_value(struct r850_tuner *t, u8 *value)
 	int ret = 0;
 	u8 tmp;
 
-	mdelay(2);
+	usleep_range(2000, 2100);
 
 	ret = r850_read_regs(t, 0x01, &tmp, 1);
 	if (!ret)
@@ -1561,7 +1561,7 @@ static int r850_calibrate_lpf(struct r850_tuner *t,
 		if (ret)
 			return ret;
 
-		mdelay(5);
+		usleep_range(5000, 5100);
 
 		ret = r850_read_adc_value(t, &val);
 		if (ret)
@@ -1576,7 +1576,7 @@ static int r850_calibrate_lpf(struct r850_tuner *t,
 		if (ret)
 			return ret;
 
-		mdelay(5);
+		usleep_range(5000, 5100);
 
 		ret = r850_read_adc_value(t, &val3);
 		if (ret)
@@ -1604,7 +1604,7 @@ static int r850_calibrate_lpf(struct r850_tuner *t,
 		if (ret)
 			return ret;
 
-		mdelay(5);
+		usleep_range(5000, 5100);
 
 		ret = r850_read_adc_value(t, &val);
 		if (ret)
@@ -1616,7 +1616,7 @@ static int r850_calibrate_lpf(struct r850_tuner *t,
 		if (ret)
 			return ret;
 
-		mdelay(5);
+		usleep_range(5000, 5100);
 
 		ret = r850_read_adc_value(t, &val2);
 		if (ret)
@@ -1636,7 +1636,7 @@ static int r850_calibrate_lpf(struct r850_tuner *t,
 		if (ret)
 			return ret;
 
-		mdelay(5);
+		usleep_range(5000, 5100);
 
 		ret = r850_read_adc_value(t, &val2);
 		if (ret)
@@ -1659,7 +1659,7 @@ static int r850_calibrate_lpf(struct r850_tuner *t,
 			if (ret)
 				return ret;
 
-			mdelay(5);
+			usleep_range(5000, 5100);
 
 			ret = r850_read_adc_value(t, &val2);
 			if (ret)

--- a/winusb/src/DriverHost_PX4/misc_win.h
+++ b/winusb/src/DriverHost_PX4/misc_win.h
@@ -21,7 +21,7 @@ typedef uint32_t u32;
 #define ARRAY_SIZE(arr)	(sizeof(arr) / sizeof((arr)[0]))
 
 #define msleep(ms)		Sleep((ms) + (16 - ((ms) % 16)))
-#define mdelay(ms)		/* do nothing*/
+#define usleep_range(min, max)	/* do nothing*/
 
 #define GFP_KERNEL	0
 #define GFP_ATOMIC	0


### PR DESCRIPTION
(from https://github.com/masnagam/px4_drv/tree/fix-mdelay)

See https://www.kernel.org/doc/Documentation/timers/timers-howto.txt.

`msleep()` was replaced with `mdelay()` in In d4cd1f2, but `mdelay(1..20)` will sleep longer as described in the documentation.

`mdelay()` will busy wait and waste hundreds of thousands of cycles on 1GHz CPU.