### PR TITLE
driver: atomic_xchgの代わりにatomic_setを使う

### DIFF
--- a/driver/isdb2056_device.c
+++ b/driver/isdb2056_device.c
@@ -1083,7 +1083,7 @@ void isdb2056_device_term(struct isdb2056_device *isdb2056)
 		"isdb2056_device_term: kref count: %u\n",
 		kref_read(&isdb2056->kref));
 
-	atomic_xchg(&isdb2056->available, 0);
+	atomic_set(&isdb2056->available, 0);
 	ptx_chrdev_group_destroy(isdb2056->chrdev_group);
 
 	kref_put(&isdb2056->kref, isdb2056_device_release);

--- a/driver/itedtv_bus.c
+++ b/driver/itedtv_bus.c
@@ -463,7 +463,7 @@ static int itedtv_usb_start_streaming(struct itedtv_bus *bus,
 #endif
 
 	usb_reset_endpoint(bus->usb.dev, 0x84);
-	atomic_xchg(&ctx->streaming, 1);
+	atomic_set(&ctx->streaming, 1);
 
 	num = ctx->num_urb;
 	works = ctx->works;
@@ -494,7 +494,7 @@ static int itedtv_usb_start_streaming(struct itedtv_bus *bus,
 	return ret;
 
 fail:
-	atomic_xchg(&ctx->streaming, 0);
+	atomic_set(&ctx->streaming, 0);
 
 #ifdef ITEDTV_BUS_USE_WORKQUEUE
 	if (ctx->wq)
@@ -517,7 +517,7 @@ static int itedtv_usb_stop_streaming(struct itedtv_bus *bus)
 
 	mutex_lock(&ctx->lock);
 
-	atomic_xchg(&ctx->streaming, 0);
+	atomic_set(&ctx->streaming, 0);
 
 #ifdef ITEDTV_BUS_USE_WORKQUEUE
 	if (ctx->wq)

--- a/driver/m1ur_device.c
+++ b/driver/m1ur_device.c
@@ -1083,7 +1083,7 @@ void m1ur_device_term(struct m1ur_device *m1ur)
 		"m1ur_device_term: kref count: %u\n",
 		kref_read(&m1ur->kref));
 
-	atomic_xchg(&m1ur->available, 0);
+	atomic_set(&m1ur->available, 0);
 	ptx_chrdev_group_destroy(m1ur->chrdev_group);
 
 	kref_put(&m1ur->kref, m1ur_device_release);

--- a/driver/ptx_chrdev.c
+++ b/driver/ptx_chrdev.c
@@ -1011,7 +1011,7 @@ void ptx_chrdev_group_destroy(struct ptx_chrdev_group *chrdev_group)
 
 	mutex_lock(&chrdev_group->lock);
 
-	atomic_xchg(&chrdev_group->available, 0);
+	atomic_set(&chrdev_group->available, 0);
 
 	for (i = 0; i < chrdev_group->chrdev_num; i++) {
 		wake_up(&chrdev_group->chrdev[i].ringbuf_wait);

--- a/driver/px4_device.c
+++ b/driver/px4_device.c
@@ -1405,7 +1405,7 @@ void px4_device_term(struct px4_device *px4)
 	dev_dbg(px4->dev,
 		"px4_device_term: kref count: %u\n", kref_read(&px4->kref));
 
-	atomic_xchg(&px4->available, 0);
+	atomic_set(&px4->available, 0);
 	ptx_chrdev_group_destroy(px4->chrdev_group);
 
 	kref_put(&px4->kref, px4_device_release);

--- a/driver/pxmlt_device.c
+++ b/driver/pxmlt_device.c
@@ -1131,7 +1131,7 @@ void pxmlt_device_term(struct pxmlt_device *pxmlt)
 {
 	dev_dbg(pxmlt->dev, "pxmlt_device_term\n");
 
-	atomic_xchg(&pxmlt->available, 0);
+	atomic_set(&pxmlt->available, 0);
 	ptx_chrdev_group_destroy(pxmlt->chrdev_group);
 
 	kref_put(&pxmlt->kref, pxmlt_device_release);

--- a/driver/ringbuffer.c
+++ b/driver/ringbuffer.c
@@ -214,7 +214,7 @@ int ringbuffer_read_user(struct ringbuffer *ringbuf,
 			head = read_size - tmp;
 		}
 
-		atomic_xchg(&ringbuf->head, head);
+		atomic_set(&ringbuf->head, head);
 		atomic_sub_return_release(read_size,
 					  &ringbuf->actual_size);
 	}
@@ -260,7 +260,7 @@ int ringbuffer_write_atomic(struct ringbuffer *ringbuf,
 			tail = write_size - tmp;
 		}
 
-		atomic_xchg(&ringbuf->tail, tail);
+		atomic_set(&ringbuf->tail, tail);
 		atomic_add_return_release(write_size,
 					  &ringbuf->actual_size);
 	}

--- a/driver/s1ur_device.c
+++ b/driver/s1ur_device.c
@@ -1097,7 +1097,7 @@ void s1ur_device_term(struct s1ur_device *s1ur)
 		"s1ur_device_term: kref count: %u\n",
 		kref_read(&s1ur->kref));
 
-	atomic_xchg(&s1ur->available, 0);
+	atomic_set(&s1ur->available, 0);
 	ptx_chrdev_group_destroy(s1ur->chrdev_group);
 
 	kref_put(&s1ur->kref, s1ur_device_release);


### PR DESCRIPTION
戻り値は確認されておらず、２つ目の因数はその後使用されていない上、
特に厳しいメモリーオーダリングは求められていないため、atomic_xchgを
利用する必要性はない。