### PR TITLE
WinUSB 版 px4_drv に ISDB2056 / ISDB2056N のサポートを追加

### DIFF
--- a/driver/isdb2056_device.c
+++ b/driver/isdb2056_device.c
@@ -79,6 +79,16 @@ static int isdb2056_backend_init(struct isdb2056_device *isdb2056)
 		return ret;
 	}
 
+	if (isdb2056->isdb2056_model == ISDB2056N_MODEL) {
+		ret = tc90522_init(&chrdev2056->tc90522_s0);
+		if (ret) {
+			dev_err(isdb2056->dev,
+				"isdb2056_backend_init: tc90522_init() (s0) failed. (ret: %d)\n",
+				ret);
+			return ret;
+		}
+	}
+
 	ret = r850_init(&chrdev2056->r850);
 	if (ret) {
 		dev_err(isdb2056->dev,
@@ -107,6 +117,8 @@ static int isdb2056_backend_term(struct isdb2056_device *isdb2056)
 
 	tc90522_term(&chrdev2056->tc90522_t);
 	tc90522_term(&chrdev2056->tc90522_s);
+	if (isdb2056->isdb2056_model == ISDB2056N_MODEL)
+		tc90522_term(&chrdev2056->tc90522_s0);
 
 	return 0;
 }

--- a/winusb/pkg/BonDriver_PX4/BonDriver_ISDB2056.ini
+++ b/winusb/pkg/BonDriver_PX4/BonDriver_ISDB2056.ini
@@ -1,0 +1,23 @@
+[BonDriver]
+Name="ISDB2056"
+System="ISDB-T,ISDB-S"
+DriverHostPath=".\DriverHost_PX4.exe"
+PipeConnectTimeout=1000
+TuneTimeout=5000
+NumberOfPacketsPerBuffer=1024
+MaximumNumberOfBuffers=64
+MinimumNumberOfBuffers=4
+NumberOfBuffersToIgnoreAfterPurge=1
+DisplayErrorMessage=0
+
+[BonDriver.ISDB-T]
+ChSetPath="BonDriver_PX4-T.ChSet.txt"
+
+[BonDriver.ISDB-S]
+ChSetPath="BonDriver_PX4-S.ChSet.txt"
+LNBPower=0
+
+[ReceiverDefinition0]
+DeviceName="Digibest ISDB2056"
+DeviceGUID="{5d04b1e3-6063-4bdd-87ce-64b916aa4180}"
+System="ISDB-T,ISDB-S"

--- a/winusb/pkg/BonDriver_PX4/BonDriver_ISDB2056N.ini
+++ b/winusb/pkg/BonDriver_PX4/BonDriver_ISDB2056N.ini
@@ -1,0 +1,23 @@
+[BonDriver]
+Name="ISDB2056N"
+System="ISDB-T,ISDB-S"
+DriverHostPath=".\DriverHost_PX4.exe"
+PipeConnectTimeout=1000
+TuneTimeout=5000
+NumberOfPacketsPerBuffer=1024
+MaximumNumberOfBuffers=64
+MinimumNumberOfBuffers=4
+NumberOfBuffersToIgnoreAfterPurge=1
+DisplayErrorMessage=0
+
+[BonDriver.ISDB-T]
+ChSetPath="BonDriver_PX4-T.ChSet.txt"
+
+[BonDriver.ISDB-S]
+ChSetPath="BonDriver_PX4-S.ChSet.txt"
+LNBPower=0
+
+[ReceiverDefinition0]
+DeviceName="Digibest ISDB2056N"
+DeviceGUID="{c29c6ef9-6321-470d-bbc9-ae4358e4c6b1}"
+System="ISDB-T,ISDB-S"

--- a/winusb/pkg/BonDriver_PX4/BonDriver_M1UR.ini
+++ b/winusb/pkg/BonDriver_PX4/BonDriver_M1UR.ini
@@ -1,0 +1,23 @@
+[BonDriver]
+Name="PX-M1UR"
+System="ISDB-T,ISDB-S"
+DriverHostPath=".\DriverHost_PX4.exe"
+PipeConnectTimeout=1000
+TuneTimeout=5000
+NumberOfPacketsPerBuffer=1024
+MaximumNumberOfBuffers=64
+MinimumNumberOfBuffers=4
+NumberOfBuffersToIgnoreAfterPurge=1
+DisplayErrorMessage=0
+
+[BonDriver.ISDB-T]
+ChSetPath="BonDriver_PX4-T.ChSet.txt"
+
+[BonDriver.ISDB-S]
+ChSetPath="BonDriver_PX4-S.ChSet.txt"
+LNBPower=0
+
+[ReceiverDefinition0]
+DeviceName="PLEX PX-M1UR"
+DeviceGUID="{a3c9bf85-13fe-465c-9a33-22441975c190}"
+System="ISDB-T,ISDB-S"

--- a/winusb/pkg/DriverHost_PX4/DriverHost_PX4.ini
+++ b/winusb/pkg/DriverHost_PX4/DriverHost_PX4.ini
@@ -402,3 +402,66 @@ Name="Digibest ISDB6014 ISDB-T/S Receiver #3"
 GUID="{2fb006ac-e388-4532-885b-555ba9f72d3d}"
 System="ISDB-T,ISDB-S"
 Index=3
+
+[DeviceDefinition10]
+Name="Digibest ISDB2056"
+GUID="{5d04b1e3-6063-4bdd-87ce-64b916aa4180}"
+Type="ISDB2056"
+DeviceInterfaceGUID="{1f8fa351-3f75-42c1-b0f1-ec794294448f}"
+
+[DeviceDefinition10.Config]
+XferPackets=816
+UrbMaxPackets=816
+MaxUrbs=5
+NoRawIo=false
+ReceiverMaxPackets=2048
+PsbPurgeTimeout=2000
+DiscardNullPackets=true
+
+[DeviceDefinition10.Receiver0]
+Name="Digibest ISDB2056 ISDB-T/S Receiver #0"
+GUID="{0aedb5cd-a9af-4aa0-b9d9-e9b378acfef6}"
+System="ISDB-T,ISDB-S"
+Index=0
+
+[DeviceDefinition11]
+Name="Digibest ISDB2056N"
+GUID="{c29c6ef9-6321-470d-bbc9-ae4358e4c6b1}"
+Type="ISDB2056"
+DeviceInterfaceGUID="{283639e3-0df2-40bd-a5cc-5051579745a7}"
+
+[DeviceDefinition11.Config]
+XferPackets=816
+UrbMaxPackets=816
+MaxUrbs=5
+NoRawIo=false
+ReceiverMaxPackets=2048
+PsbPurgeTimeout=2000
+DiscardNullPackets=true
+
+[DeviceDefinition11.Receiver0]
+Name="Digibest ISDB2056N ISDB-T/S Receiver #0"
+GUID="{0aedb5cd-a9af-4aa0-b9d9-e9b378acfef6}"
+System="ISDB-T,ISDB-S"
+Index=0
+
+[DeviceDefinition12]
+Name="PLEX PX-M1UR"
+GUID="{a3c9bf85-13fe-465c-9a33-22441975c190}"
+Type="ISDB2056"
+DeviceInterfaceGUID="{28ec1517-6150-4025-acfb-a5447add0a57}"
+
+[DeviceDefinition12.Config]
+XferPackets=816
+UrbMaxPackets=816
+MaxUrbs=5
+NoRawIo=false
+ReceiverMaxPackets=2048
+PsbPurgeTimeout=2000
+DiscardNullPackets=true
+
+[DeviceDefinition12.Receiver0]
+Name="PLEX PX-M1UR ISDB-T/S Receiver #0"
+GUID="{0aedb5cd-a9af-4aa0-b9d9-e9b378acfef6}"
+System="ISDB-T,ISDB-S"
+Index=0

--- a/winusb/pkg/inf/ISDB2056.inf
+++ b/winusb/pkg/inf/ISDB2056.inf
@@ -1,0 +1,44 @@
+;
+; Digibest ISDB2056 WinUSB
+;
+[Version]
+Signature="$Windows NT$"
+Class=Media
+ClassGuid={4d36e96c-e325-11ce-bfc1-08002be10318}
+Provider=%AuthorName%
+DriverVer=05/01/2021,21.05.01.00
+;CatalogFile=px4_drv_winusb.cat
+
+[Manufacturer]
+%AuthorName%=ISDB2056_WinUSB,ntx86,ntamd64,ntarm64
+
+[ISDB2056_WinUSB.ntx86]
+%ISDB2056_WinUSB.DeviceDesc%=ISDB2056_WinUSB.DeviceInstall,USB\VID_0511&PID_004b
+
+[ISDB2056_WinUSB.ntamd64]
+%ISDB2056_WinUSB.DeviceDesc%=ISDB2056_WinUSB.DeviceInstall,USB\VID_0511&PID_004b
+
+[ISDB2056_WinUSB.ntarm64]
+%ISDB2056_WinUSB.DeviceDesc%=ISDB2056_WinUSB.DeviceInstall,USB\VID_0511&PID_004b
+
+[ISDB2056_WinUSB.DeviceInstall]
+Include=winusb.inf
+Needs=WINUSB.NT
+AddProperty=ISDB2056_WinUSB.DeviceSetup.AddProperty
+
+[ISDB2056_WinUSB.DeviceInstall.Services]
+Include=winusb.inf
+Needs=WINUSB.NT.Services
+
+[ISDB2056_WinUSB.DeviceInstall.HW]
+AddReg=ISDB2056_WinUSB.DeviceSetup.AddReg
+
+[ISDB2056_WinUSB.DeviceSetup.AddReg]
+HKR,,DeviceInterfaceGUIDs,0x00010000,"{1f8fa351-3f75-42c1-b0f1-ec794294448f}"
+
+[ISDB2056_WinUSB.DeviceSetup.AddProperty]
+{afd97640-86a3-4210-b67c-289c41aabe55},3,0x00000011,,0   ;DEVPKEY_Device_SafeRemovalRequiredOverride=FALSE
+
+[Strings]
+AuthorName="nns779"
+ISDB2056_WinUSB.DeviceDesc="Digibest ISDB2056 ISDB-T/S Receiver Device (WinUSB)"

--- a/winusb/pkg/inf/ISDB2056N.inf
+++ b/winusb/pkg/inf/ISDB2056N.inf
@@ -1,0 +1,44 @@
+;
+; Digibest ISDB2056N WinUSB
+;
+[Version]
+Signature="$Windows NT$"
+Class=Media
+ClassGuid={4d36e96c-e325-11ce-bfc1-08002be10318}
+Provider=%AuthorName%
+DriverVer=05/01/2021,21.05.01.00
+;CatalogFile=px4_drv_winusb.cat
+
+[Manufacturer]
+%AuthorName%=ISDB2056N_WinUSB,ntx86,ntamd64,ntarm64
+
+[ISDB2056N_WinUSB.ntx86]
+%ISDB2056N_WinUSB.DeviceDesc%=ISDB2056N_WinUSB.DeviceInstall,USB\VID_0511&PID_084b
+
+[ISDB2056N_WinUSB.ntamd64]
+%ISDB2056N_WinUSB.DeviceDesc%=ISDB2056N_WinUSB.DeviceInstall,USB\VID_0511&PID_084b
+
+[ISDB2056N_WinUSB.ntarm64]
+%ISDB2056N_WinUSB.DeviceDesc%=ISDB2056N_WinUSB.DeviceInstall,USB\VID_0511&PID_084b
+
+[ISDB2056N_WinUSB.DeviceInstall]
+Include=winusb.inf
+Needs=WINUSB.NT
+AddProperty=ISDB2056N_WinUSB.DeviceSetup.AddProperty
+
+[ISDB2056N_WinUSB.DeviceInstall.Services]
+Include=winusb.inf
+Needs=WINUSB.NT.Services
+
+[ISDB2056N_WinUSB.DeviceInstall.HW]
+AddReg=ISDB2056N_WinUSB.DeviceSetup.AddReg
+
+[ISDB2056N_WinUSB.DeviceSetup.AddReg]
+HKR,,DeviceInterfaceGUIDs,0x00010000,"{283639e3-0df2-40bd-a5cc-5051579745a7}"
+
+[ISDB2056N_WinUSB.DeviceSetup.AddProperty]
+{afd97640-86a3-4210-b67c-289c41aabe55},3,0x00000011,,0   ;DEVPKEY_Device_SafeRemovalRequiredOverride=FALSE
+
+[Strings]
+AuthorName="nns779"
+ISDB2056N_WinUSB.DeviceDesc="Digibest ISDB2056N ISDB-T/S Receiver Device (WinUSB)"

--- a/winusb/pkg/inf/PX-M1UR.inf
+++ b/winusb/pkg/inf/PX-M1UR.inf
@@ -1,0 +1,44 @@
+;
+; PLEX PX-M1UR WinUSB
+;
+[Version]
+Signature="$Windows NT$"
+Class=Media
+ClassGuid={4d36e96c-e325-11ce-bfc1-08002be10318}
+Provider=%AuthorName%
+DriverVer=05/01/2021,21.05.01.00
+;CatalogFile=px4_drv_winusb.cat
+
+[Manufacturer]
+%AuthorName%=PXM1UR_WinUSB,ntx86,ntamd64,ntarm64
+
+[PXM1UR_WinUSB.ntx86]
+%PXM1UR_WinUSB.DeviceDesc%=PXM1UR_WinUSB.DeviceInstall,USB\VID_0511&PID_0854
+
+[PXM1UR_WinUSB.ntamd64]
+%PXM1UR_WinUSB.DeviceDesc%=PXM1UR_WinUSB.DeviceInstall,USB\VID_0511&PID_0854
+
+[PXM1UR_WinUSB.ntarm64]
+%PXM1UR_WinUSB.DeviceDesc%=PXM1UR_WinUSB.DeviceInstall,USB\VID_0511&PID_0854
+
+[PXM1UR_WinUSB.DeviceInstall]
+Include=winusb.inf
+Needs=WINUSB.NT
+AddProperty=PXM1UR_WinUSB.DeviceSetup.AddProperty
+
+[PXM1UR_WinUSB.DeviceInstall.Services]
+Include=winusb.inf
+Needs=WINUSB.NT.Services
+
+[PXM1UR_WinUSB.DeviceInstall.HW]
+AddReg=PXM1UR_WinUSB.DeviceSetup.AddReg
+
+[PXM1UR_WinUSB.DeviceSetup.AddReg]
+HKR,,DeviceInterfaceGUIDs,0x00010000,"{28ec1517-6150-4025-acfb-a5447add0a57}"
+
+[PXM1UR_WinUSB.DeviceSetup.AddProperty]
+{afd97640-86a3-4210-b67c-289c41aabe55},3,0x00000011,,0   ;DEVPKEY_Device_SafeRemovalRequiredOverride=FALSE
+
+[Strings]
+AuthorName="nns779"
+PXM1UR_WinUSB.DeviceDesc="PLEX PX-M1UR ISDB-T/S Receiver Device (WinUSB)"

--- a/winusb/src/BonDriver_PX4/BonDriver_PX4.vcxproj
+++ b/winusb/src/BonDriver_PX4/BonDriver_PX4.vcxproj
@@ -36,14 +36,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
@@ -51,7 +51,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-static|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
@@ -59,14 +59,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
@@ -74,7 +74,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-static|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>

--- a/winusb/src/DriverHost_PX4/DriverHost_PX4.vcxproj
+++ b/winusb/src/DriverHost_PX4/DriverHost_PX4.vcxproj
@@ -36,14 +36,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
@@ -51,7 +51,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-static|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
@@ -59,14 +59,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
@@ -74,7 +74,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-static|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
@@ -259,6 +259,7 @@
     <ClCompile Include="device_manager.cpp" />
     <ClCompile Include="device_notifier.cpp" />
     <ClCompile Include="driver_host.cpp" />
+    <ClCompile Include="isdb2056_device.cpp" />
     <ClCompile Include="itedtv_bus_winusb.c" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="misc_win.c" />
@@ -294,6 +295,7 @@
     <ClInclude Include="device_manager.hpp" />
     <ClInclude Include="device_notifier.hpp" />
     <ClInclude Include="driver_host.hpp" />
+    <ClInclude Include="isdb2056_device.hpp" />
     <ClInclude Include="misc_win.h" />
     <ClInclude Include="notify_icon.hpp" />
     <ClInclude Include="pipe_server.hpp" />

--- a/winusb/src/DriverHost_PX4/DriverHost_PX4.vcxproj.filters
+++ b/winusb/src/DriverHost_PX4/DriverHost_PX4.vcxproj.filters
@@ -105,6 +105,9 @@
     <ClCompile Include="notify_icon.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
+    <ClCompile Include="isdb2056_device.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\driver\cxd2856er.h">
@@ -204,6 +207,9 @@
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
     <ClInclude Include="winusb_compat.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="isdb2056_device.hpp">
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
   </ItemGroup>

--- a/winusb/src/DriverHost_PX4/device_manager.cpp
+++ b/winusb/src/DriverHost_PX4/device_manager.cpp
@@ -9,6 +9,7 @@
 
 #include "px4_device.hpp"
 #include "pxmlt_device.hpp"
+#include "isdb2056_device.hpp"
 
 namespace px4 {
 
@@ -47,6 +48,8 @@ DeviceManager::DeviceManager(const px4::DeviceDefinitionSet &device_defs, px4::R
 			type = DeviceType::PX4;
 		else if (it->first == L"PXMLT")
 			type = DeviceType::PXMLT;
+		else if (it->first == L"ISDB2056")
+			type = DeviceType::ISDB2056;
 
 		if (type == DeviceType::UNKNOWN)
 			continue;
@@ -129,6 +132,16 @@ void DeviceManager::Add(const std::wstring &path, const std::pair<DeviceType, px
 	case px4::DeviceType::PXMLT:
 	{
 		auto dev = std::make_unique<PxMltDevice>(path, def.second, ++index_, receiver_manager_);
+
+		if (!dev->Init())
+			devices_.emplace(path, std::move(dev));
+
+		break;
+	}
+
+	case px4::DeviceType::ISDB2056:
+	{
+		auto dev = std::make_unique<Isdb2056Device>(path, def.second, ++index_, receiver_manager_);
 
 		if (!dev->Init())
 			devices_.emplace(path, std::move(dev));

--- a/winusb/src/DriverHost_PX4/device_manager.hpp
+++ b/winusb/src/DriverHost_PX4/device_manager.hpp
@@ -22,7 +22,8 @@ namespace px4 {
 enum class DeviceType : std::uint32_t {
 	UNKNOWN = 0,
 	PX4,
-	PXMLT
+	PXMLT,
+	ISDB2056,
 };
 
 class DeviceManager final {

--- a/winusb/src/DriverHost_PX4/isdb2056_device.cpp
+++ b/winusb/src/DriverHost_PX4/isdb2056_device.cpp
@@ -1,0 +1,1211 @@
+// isdb2056_device.cpp
+
+#include "isdb2056_device.hpp"
+
+#include <cassert>
+#include <cmath>
+
+#include "type.hpp"
+#include "command.hpp"
+#include "misc_win.h"
+
+namespace px4 {
+
+Isdb2056Device::Isdb2056Device(const std::wstring &path, const px4::DeviceDefinition &device_def, std::uintptr_t index, px4::ReceiverManager &receiver_manager)
+	: DeviceBase(path, device_def, index, receiver_manager),
+	config_(),
+	lock_(),
+	available_(true),
+	init_(false),
+	streaming_count_(0)
+{
+	if (usb_dev_.descriptor.idVendor != 0x0511)
+		throw DeviceError("px4::Isdb2056Device::Isdb2056Device: unsupported device. (unknown vendor id)");
+
+	switch (usb_dev_.descriptor.idProduct) {
+	case 0x004b:
+		model_ = Isdb2056DeviceModel::ISDB2056;
+		break;
+
+	case 0x084b:
+		model_ = Isdb2056DeviceModel::ISDB2056N;
+		break;
+
+	case 0x0854:
+		model_ = Isdb2056DeviceModel::PXM1UR;
+		break;
+
+	default:
+		model_ = Isdb2056DeviceModel::OTHER;
+	}
+
+	LoadConfig();
+
+	memset(&it930x_, 0, sizeof(it930x_));
+	memset(&stream_ctx_, 0, sizeof(stream_ctx_));
+}
+
+Isdb2056Device::~Isdb2056Device()
+{
+	Term();
+}
+
+void Isdb2056Device::LoadConfig()
+{
+	auto &configs = device_def_.configs;
+
+	if (configs.Exists(L"XferPackets"))
+		config_.usb.xfer_packets = px4::util::wtoui(configs.Get(L"XferPackets"));
+
+	if (configs.Exists(L"UrbMaxPackets"))
+		config_.usb.urb_max_packets = px4::util::wtoui(configs.Get(L"UrbMaxPackets"));
+
+	if (configs.Exists(L"MaxUrbs"))
+		config_.usb.max_urbs = px4::util::wtoui(configs.Get(L"MaxUrbs"));
+
+	if (configs.Exists(L"NoRawIo"))
+		config_.usb.no_raw_io = px4::util::wtob(configs.Get(L"NoRawIo"));
+
+	if (configs.Exists(L"ReceiverMaxPackets"))
+		config_.device.receiver_max_packets = px4::util::wtoui(configs.Get(L"ReceiverMaxPackets"));
+
+	if (configs.Exists(L"PsbPurgeTimeout"))
+		config_.device.psb_purge_timeout = px4::util::wtoi(configs.Get(L"PsbPurgeTimeout"));
+
+	if (configs.Exists(L"DiscardNullPackets"))
+		config_.device.discard_null_packets = px4::util::wtob(configs.Get(L"DiscardNullPackets"));
+
+	dev_dbg(&dev_, "px4::Isdb2056Device::LoadConfig: model: %d\n", model_);
+	dev_dbg(&dev_, "px4::Isdb2056Device::LoadConfig: xfer_packets: %u\n", config_.usb.xfer_packets);
+	dev_dbg(&dev_, "px4::Isdb2056Device::LoadConfig: urb_max_packets: %u\n", config_.usb.urb_max_packets);
+	dev_dbg(&dev_, "px4::Isdb2056Device::LoadConfig: max_urbs: %u\n", config_.usb.max_urbs);
+	dev_dbg(&dev_, "px4::Isdb2056Device::LoadConfig: no_raw_io: %s\n", (config_.usb.no_raw_io) ? "true" : "false");
+	dev_dbg(&dev_, "px4::Isdb2056Device::LoadConfig: receiver_max_packets: %u\n", config_.device.receiver_max_packets);
+	dev_dbg(&dev_, "px4::Isdb2056Device::LoadConfig: psb_purge_timeout: %i\n", config_.device.psb_purge_timeout);
+	dev_dbg(&dev_, "px4::Isdb2056Device::LoadConfig: discard_null_packets: %s\n", (config_.device.discard_null_packets) ? "true" : "false");
+
+	return;
+}
+
+int Isdb2056Device::Init()
+{
+	dev_dbg(&dev_, "px4::Isdb2056Device::Init: init_: %s\n", (init_) ? "true" : "false");
+
+	std::lock_guard<std::recursive_mutex> lock(lock_);
+
+	if (init_)
+		return -EALREADY;
+
+	int ret = 0;
+	itedtv_bus &bus = it930x_.bus;
+	it930x_stream_input& input = it930x_.config.input[0];
+
+	bus.dev = &dev_;
+	bus.type = ITEDTV_BUS_USB;
+	bus.usb.dev = &usb_dev_;
+	bus.usb.ctrl_timeout = 3000;
+
+	it930x_.dev = &dev_;
+	it930x_.config.xfer_size = 188 * config_.usb.xfer_packets;
+	it930x_.config.i2c_speed = 0x07;
+
+	ret = itedtv_bus_init(&bus);
+	if (ret)
+		goto fail_bus;
+
+	ret = it930x_init(&it930x_);
+	if (ret)
+		goto fail_bridge;
+
+	input.enable = true;
+	input.is_parallel = false;
+	input.port_number = 0;
+	input.slave_number = 0;
+	input.i2c_bus = 3;
+	input.i2c_addr = 0x10;
+	input.packet_len = 188;
+	input.sync_byte = 0x47;
+
+	for (int i = 1; i < 5; i++) {
+		it930x_.config.input[i].enable = false;
+		it930x_.config.input[i].port_number = i;
+	}
+
+	receiver_.reset(new Isdb2056Receiver(*this, 0));
+	stream_ctx_.stream_buf = receiver_->GetStreamBuffer();
+
+	ret = it930x_raise(&it930x_);
+	if (ret)
+		goto fail_device;
+
+	ret = it930x_load_firmware(&it930x_, "it930x-firmware.bin");
+	if (ret)
+		goto fail_device;
+
+	ret = it930x_init_warm(&it930x_);
+	if (ret)
+		goto fail_device;
+
+	/* GPIO */
+	ret = it930x_set_gpio_mode(&it930x_, 3, IT930X_GPIO_OUT, true);
+	if (ret)
+		goto fail_device;
+
+	ret = it930x_write_gpio(&it930x_, 3, true);
+	if (ret)
+		goto fail_device;
+
+	ret = it930x_set_gpio_mode(&it930x_, 2, IT930X_GPIO_OUT, true);
+	if (ret)
+		goto fail_device;
+
+	ret = it930x_write_gpio(&it930x_, 2, false);
+	if (ret)
+		goto fail_device;
+
+#if 0
+	ret = it930x_set_gpio_mode(&it930x_, 11, IT930X_GPIO_OUT, true);
+	if (ret)
+		goto fail_device;
+
+	/* LNB power supply: off */
+	ret = it930x_write_gpio(&it930x_, 11, false);
+	if (ret)
+		goto fail_device;
+#endif
+
+	if (config_.device.discard_null_packets) {
+		it930x_pid_filter filter;
+
+		filter.block = true;
+		filter.num = 1;
+		filter.pid[0] = 0x1fff;
+
+		ret = it930x_set_pid_filter(&it930x_, 0, &filter);
+		if (ret)
+			goto fail_device;
+	}
+
+	init_ = true;
+
+	for (auto it = device_def_.receivers.cbegin(); it != device_def_.receivers.cend(); ++it) {
+		px4::command::ReceiverInfo ri;
+
+		wcscpy_s(ri.device_name, device_def_.name.c_str());
+		ri.device_guid = device_def_.guid;
+		wcscpy_s(ri.receiver_name, it->name.c_str());
+		ri.receiver_guid = it->guid;
+		ri.systems = it->systems;
+		ri.index = it->index;
+		ri.data_id = 0;
+
+		receiver_manager_.Register(ri, receiver_.get());
+	}
+
+	return 0;
+
+fail_device:
+	stream_ctx_.stream_buf = nullptr;
+	receiver_.reset();
+
+	it930x_term(&it930x_);
+
+fail_bridge:
+	itedtv_bus_term(&bus);
+
+fail_bus:
+	return ret;
+}
+
+void Isdb2056Device::Term()
+{
+	dev_dbg(&dev_, "px4::Isdb2056Device::Term: init_: %s\n", (init_) ? "true" : "false");
+
+	std::unique_lock<std::recursive_mutex> lock(lock_);
+
+	if (!init_)
+		return;
+
+	receiver_manager_.Unregister(receiver_.get());
+
+	lock.unlock();
+
+	stream_ctx_.stream_buf = nullptr;
+	receiver_.reset();
+
+	lock.lock();
+
+	it930x_term(&it930x_);
+	itedtv_bus_term(&it930x_.bus);
+
+	init_ = false;
+	return;
+}
+
+void Isdb2056Device::SetAvailability(bool available)
+{
+	available_ = available;
+}
+
+ReceiverBase* Isdb2056Device::GetReceiver(int id) const
+{
+	if (id != 0)
+		throw std::out_of_range("receiver id out of range");
+
+	return receiver_.get();
+}
+
+const i2c_comm_master& Isdb2056Device::GetI2cMaster(int bus) const
+{
+	if (bus < 1 || bus > 3)
+		throw std::out_of_range("bus number out of range");
+
+	return it930x_.i2c_master[bus - 1];
+}
+
+int Isdb2056Device::SetBackendPower(bool state)
+{
+	dev_dbg(&dev_, "px4::Isdb2056Device::SetBackendPower: %s\n", (state) ? "true" : "false");
+
+	int ret = 0;
+	std::lock_guard<std::recursive_mutex> lock(lock_);
+	
+	if (!state && !available_)
+		return 0;
+
+	if (state) {
+		ret = it930x_write_gpio(&it930x_, 3, false);
+		if (ret)
+			return ret;
+
+		Sleep(100);
+
+		ret = it930x_write_gpio(&it930x_, 2, true);
+		if (ret)
+			return ret;
+
+		Sleep(20);
+	} else {
+		it930x_write_gpio(&it930x_, 2, false);
+		it930x_write_gpio(&it930x_, 3, true);
+	}
+
+	return 0;
+}
+
+int Isdb2056Device::SetLnbVoltage(std::int32_t voltage)
+{
+	dev_dbg(&dev_, "px4::Isdb2056Device::SetBackendPower: voltage: %d\n", voltage);
+
+	return 0;
+}
+
+int Isdb2056Device::PrepareCapture()
+{
+	dev_dbg(&dev_, "px4::Isdb2056Device::PrepareCapture\n");
+
+	int ret = 0;
+	std::lock_guard<std::recursive_mutex> lock(lock_);
+
+	if (streaming_count_)
+		return 0;
+
+	ret = it930x_purge_psb(&it930x_, config_.device.psb_purge_timeout);
+	if (ret)
+		dev_err(&dev_, "px4::Isdb2056Device::PrepareCapture: it930x_purge_psb() failed. (ret: %d)\n", ret);
+
+	return (ret && ret != -ETIMEDOUT) ? ret : 0;
+}
+
+int Isdb2056Device::StartCapture()
+{
+	dev_dbg(&dev_, "px4::Isdb2056Device::StartCapture\n");
+
+	int ret = 0;
+	std::lock_guard<std::recursive_mutex> lock(lock_);
+
+	if (!streaming_count_) {
+		it930x_.bus.usb.streaming.urb_buffer_size = 188 * config_.usb.urb_max_packets;
+		it930x_.bus.usb.streaming.urb_num = config_.usb.max_urbs;
+		it930x_.bus.usb.streaming.no_dma = true;
+		it930x_.bus.usb.streaming.no_raw_io = config_.usb.no_raw_io;
+
+		stream_ctx_.remain_len = 0;
+
+		ret = itedtv_bus_start_streaming(&it930x_.bus, StreamHandler, this);
+		if (ret) {
+			dev_err(&dev_, "px4::Isdb2056Device::StartCapture: itedtv_bus_start_streaming() failed. (ret: %d)\n", ret);
+			return ret;
+		}
+		streaming_count_++;
+	}
+
+	dev_dbg(&dev_, "px4::Isdb2056Device::StartCapture: streaming_count_: %u\n", streaming_count_);
+
+	return 0;
+}
+
+int Isdb2056Device::StopCapture()
+{
+	dev_dbg(&dev_, "px4::Isdb2056Device::StopCapture\n");
+
+	std::lock_guard<std::recursive_mutex> lock(lock_);
+
+	if (streaming_count_) {
+		dev_dbg(&dev_, "px4::Isdb2056Device::StopCapture: stopping...\n");
+		itedtv_bus_stop_streaming(&it930x_.bus);
+		streaming_count_ = 0;
+	}
+
+	return 0;
+}
+
+void Isdb2056Device::StreamProcess(std::shared_ptr<px4::ReceiverBase::StreamBuffer> stream_buf, std::uint8_t **buf, std::size_t &len)
+{
+	std::uint8_t *p = *buf;
+	std::size_t remain = len;
+
+	while (remain) {
+		std::size_t i = 0;
+		bool sync_remain = false;
+
+		while (true) {
+			if (((i + 1) * 188) <= remain) {
+				if (p[i * 188] == 0x47)
+					break;
+			} else {
+				sync_remain = true;
+				break;
+			}
+			i++;
+		}
+
+		if (i < ISDB2056_DEVICE_TS_SYNC_COUNT) {
+			p++;
+			remain--;
+			continue;
+		}
+
+		std::size_t pkt_len = 188 * i;
+		stream_buf->Write(p, pkt_len);
+
+		p += 188 * i;
+		remain -= 188 * i;
+
+		if (sync_remain)
+			break;
+	}
+
+	stream_buf->NotifyWrite();
+
+	*buf = p;
+	len = remain;
+
+	return;
+}
+
+int Isdb2056Device::StreamHandler(void *context, void *buf, std::uint32_t len)
+{
+	Isdb2056Device &obj = *static_cast<Isdb2056Device*>(context);
+	StreamContext &stream_ctx = obj.stream_ctx_;
+	std::uint8_t *p = static_cast<std::uint8_t*>(buf);
+	std::size_t remain = len;
+
+	if (stream_ctx.remain_len) {
+		if ((stream_ctx.remain_len + len) >= ISDB2056_DEVICE_TS_SYNC_SIZE) {
+			std::uint8_t * remain_buf = stream_ctx.remain_buf;
+			std::size_t t = ISDB2056_DEVICE_TS_SYNC_SIZE - stream_ctx.remain_len;
+
+			memcpy(remain_buf + stream_ctx.remain_len, p, t);
+			stream_ctx.remain_len = ISDB2056_DEVICE_TS_SYNC_SIZE;
+
+			StreamProcess(stream_ctx.stream_buf, &remain_buf, stream_ctx.remain_len);
+			if (!stream_ctx.remain_len) {
+				p += t;
+				remain -= t;
+			}
+
+			stream_ctx.remain_len = 0;
+		} else {
+			memcpy(stream_ctx.remain_buf + stream_ctx.remain_len, p, len);
+			stream_ctx.remain_len += len;
+
+			return 0;
+		}
+	}
+
+	StreamProcess(stream_ctx.stream_buf, &p, remain);
+
+	if (remain) {
+		memcpy(stream_ctx.remain_buf, p, remain);
+		stream_ctx.remain_len = remain;
+	}
+
+	return 0;
+}
+
+struct tc90522_regbuf Isdb2056Device::Isdb2056Receiver::tc_init_t_[] = {
+	{ 0xb0, NULL, { 0xa0 } },
+	{ 0xb2, NULL, { 0x3d } },
+	{ 0xb3, NULL, { 0x25 } },
+	{ 0xb4, NULL, { 0x8b } },
+	{ 0xb5, NULL, { 0x4b } },
+	{ 0xb6, NULL, { 0x3f } },
+	{ 0xb7, NULL, { 0xff } },
+	{ 0xb8, NULL, { 0xc0 } },
+};
+
+struct tc90522_regbuf Isdb2056Device::Isdb2056Receiver::tc_init_s_[] = {
+	{ 0x15, NULL, { 0x00 } },
+	{ 0x1d, NULL, { 0x00 } },
+};
+
+Isdb2056Device::Isdb2056Receiver::Isdb2056Receiver(Isdb2056Device &parent, std::uintptr_t index)
+	: ReceiverBase(RECEIVER_SAT_SET_STREAM_ID_AFTER_TUNE | RECEIVER_WAIT_AFTER_LOCK_TC_T),
+	parent_(parent),
+	index_(index),
+	lock_(),
+	init_(false),
+	open_(false),
+	lnb_power_(false),
+	streaming_(false)
+{
+	memset(&r850_, 0, sizeof(r850_));
+	memset(&rt710_, 0, sizeof(rt710_));
+
+	current_system_ = px4::SystemType::UNSPECIFIED;
+
+	const device *dev = &parent_.GetDevice();
+	const i2c_comm_master *i2c = &parent_.GetI2cMaster(parent_.it930x_.config.input[0].i2c_bus);
+
+	tc90522_t_.dev = dev;
+	tc90522_t_.i2c = i2c;
+	tc90522_t_.i2c_addr = 0x10;
+	tc90522_t_.is_secondary = false;
+
+	tc90522_s0_.dev = dev;
+	tc90522_s0_.i2c = i2c;
+	tc90522_s0_.i2c_addr = 0x11;
+	tc90522_s0_.is_secondary = false;
+
+	tc90522_s_.dev = dev;
+	tc90522_s_.i2c = i2c;
+	tc90522_s_.i2c_addr = (parent_.model_ == px4::Isdb2056DeviceModel::ISDB2056N) ? 0x13 : 0x11;
+	tc90522_s_.is_secondary = (parent_.model_ == px4::Isdb2056DeviceModel::ISDB2056N) ? true : false;
+
+	r850_.dev = dev;
+	r850_.i2c = &tc90522_t_.i2c_master;
+	r850_.i2c_addr = 0x7c;
+	r850_.config.xtal = 24000;
+	r850_.config.loop_through = !tc90522_t_.is_secondary;
+	r850_.config.clock_out = false;
+	r850_.config.no_imr_calibration = true;
+	r850_.config.no_lpf_calibration = true;
+
+	rt710_.dev = dev;
+	rt710_.i2c = &tc90522_s_.i2c_master;
+	rt710_.i2c_addr = 0x7a;
+	rt710_.config.xtal = 24000;
+	rt710_.config.loop_through = false;
+	rt710_.config.clock_out = false;
+	rt710_.config.signal_output_mode = RT710_SIGNAL_OUTPUT_DIFFERENTIAL;
+	rt710_.config.agc_mode = RT710_AGC_POSITIVE;
+	rt710_.config.vga_atten_mode = RT710_VGA_ATTEN_OFF;
+	rt710_.config.fine_gain = RT710_FINE_GAIN_3DB;
+	rt710_.config.scan_mode = RT710_SCAN_MANUAL;
+}
+
+Isdb2056Device::Isdb2056Receiver::~Isdb2056Receiver()
+{
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::~Isdb2056Receiver(%u)\n", index_);
+
+	std::unique_lock<std::mutex> lock(lock_);
+
+	close_cond_.wait(lock, [this] { return !open_; });
+
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::~Isdb2056Receiver(%u): exit\n", index_);
+}
+
+int Isdb2056Device::Isdb2056Receiver::Init(bool sleep)
+{
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Init(%u): init_: %s, sleep: %s\n", index_, (init_) ? "true" : "false", (sleep) ? "true" : "false");
+
+	int ret = 0;
+	std::lock_guard<std::recursive_mutex> dev_lock(parent_.lock_);
+
+	if (init_)
+		return 0;
+
+	ret = tc90522_init(&tc90522_t_);
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Init(%u): tc90522_init() (t) failed. (ret: %d)\n", index_, ret);
+		return ret;
+	}
+
+	ret = tc90522_init(&tc90522_s0_);
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Init(%u): tc90522_init() (s0) failed. (ret: %d)\n", index_, ret);
+		return ret;
+	}
+
+	ret = tc90522_init(&tc90522_s_);
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Init(%u): tc90522_init() (s) failed. (ret: %d)\n", index_, ret);
+		return ret;
+	}
+
+	ret = r850_init(&r850_);
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Init(%u): r850_init() failed. (ret: %d)\n", index_, ret);
+		return ret;
+	}
+
+	if (sleep) {
+		ret = r850_sleep(&r850_);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Init(%u): r850_sleep() failed. (ret: %d)\n", index_, ret);
+			return ret;
+		}
+
+		ret = tc90522_sleep_t(&tc90522_t_, true);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Init(%u): tc90522_sleep_t(true) failed. (ret: %d)\n", index_, ret);
+			return ret;
+		}
+	}
+
+	ret = rt710_init(&rt710_);
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Init(%u): rt710_init() failed. (ret: %d)\n", index_, ret);
+		return ret;
+	}
+
+	if (sleep) {
+		ret = rt710_sleep(&rt710_);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Init(%u): rt710_sleep() failed. (ret: %d)\n", index_, ret);
+			return ret;
+		}
+
+		ret = tc90522_sleep_s(&tc90522_s_, true);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Init(%u): tc90522_sleep_s(true) failed. (ret: %d)\n", index_, ret);
+			return ret;
+		}
+	}
+
+	if (!ret)
+		init_.store(true);
+
+	return ret;
+}
+
+void Isdb2056Device::Isdb2056Receiver::Term()
+{
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Term(%u): init_: %s\n", index_, (init_) ? "true" : "false");
+
+	std::lock_guard<std::recursive_mutex> dev_lock(parent_.lock_);
+
+	if (!init_)
+		return;
+
+	r850_term(&r850_);
+	rt710_term(&rt710_);
+
+	tc90522_term(&tc90522_t_);
+	tc90522_term(&tc90522_s0_);
+	tc90522_term(&tc90522_s_);
+
+	init_ = false;
+
+	return;
+}
+
+int Isdb2056Device::Isdb2056Receiver::Open()
+{
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): init_: %s, open_: %s\n", index_, (init_) ? "true" : "false", (open_) ? "true" : "false");
+
+	int ret = 0;
+	std::unique_lock<std::mutex> lock(lock_);
+	std::unique_lock<std::recursive_mutex> dev_lock(parent_.lock_);
+
+	if (open_)
+		return (!init_) ? -EINVAL : -EALREADY;
+
+	ret = parent_.SetBackendPower(true);
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): parent_.SetBackendPower(true) failed. (ret: %d)\n", index_, ret);
+		return ret;
+	}
+
+	ret = parent_.receiver_->Init(true);
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): parent_.reciver_->Init(true) failed. (ret: %d)\n", index_, ret);
+		parent_.SetBackendPower(false);
+		return ret;
+	}
+
+	ret = tc90522_write_multiple_regs(&tc90522_t_, tc_init_t_, ARRAY_SIZE(tc_init_t_));
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_write_multiple_regs(tc_init_t) failed. (ret: %d)\n", index_, ret);
+		goto fail;
+	}
+
+	ret = tc90522_enable_ts_pins_t(&tc90522_t_, false);
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_enable_ts_pins_t(false) failed. (ret: %d)\n", index_, ret);
+		goto fail;
+	}
+
+	ret = tc90522_sleep_t(&tc90522_t_, true);
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_sleep_t(false) failed. (ret: %d)\n", index_, ret);
+		goto fail;
+	}
+
+	ret = r850_wakeup(&r850_);
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): r850_wakeup() failed. (ret: %d)\n", index_, ret);
+		goto fail;
+	}
+
+	r850_system_config sys;
+
+	sys.system = R850_SYSTEM_ISDB_T;
+	sys.bandwidth = R850_BANDWIDTH_6M;
+	sys.if_freq = 4063;
+
+	ret = r850_set_system(&r850_, &sys);
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): r850_set_system() failed. (ret: %d)\n", index_, ret);
+		goto fail;
+	}
+
+	ret = tc90522_write_multiple_regs(&tc90522_s_, tc_init_s_, ARRAY_SIZE(tc_init_s_));
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_write_multiple_regs(tc_init_s) failed. (ret: %d)\n", index_, ret);
+		goto fail;
+	}
+
+	ret = tc90522_enable_ts_pins_s(&tc90522_s_, false);
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_enable_ts_pins_s(false) failed. (ret: %d)\n", index_, ret);
+		goto fail;
+	}
+
+	ret = tc90522_sleep_s(&tc90522_s_, true);
+	if (ret) {
+		dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_sleep_s(false) failed. (ret: %d)\n", index_, ret);
+		goto fail;
+	}
+
+	open_ = true;
+	return ret;
+
+fail:
+	parent_.Term();
+	parent_.SetBackendPower(false);
+	return ret;
+}
+
+void Isdb2056Device::Isdb2056Receiver::Close()
+{
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Close(%u): init_: %s, open_: %s\n", index_, (init_) ? "true" : "false", (open_) ? "true" : "false");
+
+	if (!init_ || !open_)
+		return;
+
+	SetCapture(false);
+	SetLnbVoltage(0);
+
+	std::unique_lock<std::mutex> lock(lock_);
+	std::lock_guard<std::recursive_mutex> dev_lock(parent_.lock_);
+
+	parent_.receiver_->Term();
+	parent_.SetBackendPower(false);
+
+	open_ = false;
+
+	lock.unlock();
+	close_cond_.notify_all();
+
+	return;
+}
+
+int Isdb2056Device::Isdb2056Receiver::SetFrequency()
+{
+	if (!init_ || !open_)
+		return -EINVAL;
+
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::SetFrequency(%u): system: %d freq: %u\n", index_, params_.system, params_.freq);
+
+	int ret = 0;
+	std::lock_guard<std::mutex> lock(lock_);
+
+	switch (params_.system) {
+	case px4::SystemType::ISDB_T:
+	{
+		ret = tc90522_write_reg(&tc90522_t_, 0x47, 0x30);
+		if (ret)
+			break;
+
+		ret = tc90522_set_agc_t(&tc90522_t_, false);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_set_agc_t(false) failed. (ret: %d)\n", index_, ret);
+			break;
+		}
+
+		ret = tc90522_sleep_s(&tc90522_s_, true);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_sleep_s(true) failed. (ret: %d)\n", index_, ret);
+			break;
+		}
+
+		ret = tc90522_write_reg(&tc90522_t_, 0x0e, 0x77);
+		if (ret)
+			break;
+
+		ret = tc90522_write_reg(&tc90522_t_, 0x0f, 0x10);
+		if (ret)
+			break;
+
+		ret = tc90522_write_reg(&tc90522_t_, 0x71, 0x20);
+		if (ret)
+			break;
+
+		ret = tc90522_sleep_t(&tc90522_t_, false);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_sleep_t(false) failed. (ret: %d)\n", index_, ret);
+			break;
+		}
+
+		ret = tc90522_write_reg(&tc90522_t_, 0x76, 0x0c);
+		if (ret)
+			break;
+
+		ret = tc90522_write_reg(&tc90522_t_, 0x1f, 0x30);
+		if (ret)
+			break;
+
+		ret = r850_wakeup(&r850_);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): r850_wakeup() failed. (ret: %d)\n", index_, ret);
+			break;
+		}
+
+		ret = r850_set_frequency(&r850_, params_.freq);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): r850_set_frequency(%u) failed. (ret: %d)\n", index_, params_.freq, ret);
+			break;
+		}
+
+		bool tuner_locked = false;
+
+		for (int i = 25; i; i--) {
+			ret = r850_is_pll_locked(&r850_, &tuner_locked);
+			if (!ret && tuner_locked)
+				break;
+
+			Sleep(20);
+		}
+
+		if (ret)
+			break;
+
+		if (!tuner_locked) {
+			dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::SetFrequency(%u): tuner is NOT locked.\n", index_);
+			ret = -EAGAIN;
+			break;
+		}
+
+		ret = tc90522_set_agc_t(&tc90522_t_, true);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_set_agc_t(true) failed. (ret: %d)\n", index_, ret);
+			break;
+		}
+
+		ret = tc90522_write_reg(&tc90522_t_, 0x71, 0x01);
+		if (ret)
+			break;
+
+		ret = tc90522_write_reg(&tc90522_t_, 0x72, 0x25);
+		if (ret)
+			break;
+
+		ret = tc90522_write_reg(&tc90522_t_, 0x75, 0x00);
+		if (ret)
+			break;
+
+		break;
+	}
+
+	case px4::SystemType::ISDB_S:
+	{
+		ret = tc90522_set_agc_s(&tc90522_s_, false);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_set_agc_s(false) failed. (ret: %d)\n", index_, ret);
+			break;
+		}
+
+		ret = tc90522_write_reg(&tc90522_t_, 0x0e, 0x11);
+		if (ret)
+			break;
+
+		ret = tc90522_write_reg(&tc90522_t_, 0x0f, 0x70);
+		if (ret)
+			break;
+
+		ret = tc90522_sleep_t(&tc90522_t_, true);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_sleep_t(true) failed. (ret: %d)\n", index_, ret);
+			break;
+		}
+
+		switch (parent_.model_) {
+		case px4::Isdb2056DeviceModel::ISDB2056:
+		case px4::Isdb2056DeviceModel::PXM1UR:
+			ret = tc90522_write_reg(&tc90522_s_, 0x07, 0x77);
+			break;
+
+		case px4::Isdb2056DeviceModel::ISDB2056N:
+			ret = tc90522_write_reg(&tc90522_s0_, 0x07, 0x77);
+			break;
+
+		default:
+			ret = tc90522_write_reg(&tc90522_s_, 0x07, 0x77);
+			break;
+		}
+
+		if (ret)
+			break;
+
+		switch (parent_.model_) {
+		case px4::Isdb2056DeviceModel::ISDB2056:
+		case px4::Isdb2056DeviceModel::PXM1UR:
+			ret = tc90522_write_reg(&tc90522_s_, 0x08, 0x10);
+			break;
+
+		case px4::Isdb2056DeviceModel::ISDB2056N:
+			ret = tc90522_write_reg(&tc90522_s0_, 0x08, 0x37);
+			break;
+
+		default:
+			ret = tc90522_write_reg(&tc90522_s_, 0x08, 0x10);
+			break;
+		}
+
+		if (ret)
+			break;
+
+		ret = tc90522_sleep_s(&tc90522_s_, false);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_sleep_s(false) failed. (ret: %d)\n", index_, ret);
+			break;
+		}
+
+		ret = tc90522_write_reg(&tc90522_s_, 0x04, 0x02);
+		if (ret)
+			break;
+
+		ret = tc90522_write_reg(&tc90522_s_, 0x8e, 0x02);
+		if (ret)
+			break;
+
+		ret = tc90522_write_reg(&tc90522_t_, 0x1f, 0x20);
+		if (ret)
+			break;
+
+		ret = rt710_set_params(&rt710_, params_.freq, 28860, 4);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): rt710_set_params(%u) failed. (ret: %d)\n", index_, params_.freq, ret);
+			break;
+		}
+
+		bool tuner_locked = false;
+
+		for (int i = 25; i; i--) {
+			ret = rt710_is_pll_locked(&rt710_, &tuner_locked);
+			if (!ret && tuner_locked)
+				break;
+
+			Sleep(20);
+		}
+
+		if (ret)
+			break;
+
+		if (!tuner_locked) {
+			dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::SetFrequency(%u): tuner is NOT locked.\n", index_);
+			ret = -EAGAIN;
+			break;
+		}
+
+		ret = tc90522_set_agc_s(&tc90522_s_, true);
+		if (ret) {
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::Open(%u): tc90522_set_agc_s(true) failed. (ret: %d)\n", index_, ret);
+			break;
+		}
+
+		break;
+	}
+
+	default:
+		ret = -EINVAL;
+		break;
+	}
+
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::SetFrequency(%u): %s.\n", index_, (!ret) ? "succeeded" : "failed");
+
+	if (!ret) {
+		current_system_ = params_.system;
+	}
+	else {
+		current_system_ = px4::SystemType::UNSPECIFIED;
+	}
+
+	return ret;
+}
+
+int Isdb2056Device::Isdb2056Receiver::CheckLock(bool &locked)
+{
+	if (!init_ || !open_)
+		return -EINVAL;
+
+	int ret = 0;
+	std::lock_guard<std::mutex> lock(lock_);
+
+	switch (current_system_) {
+	case px4::SystemType::ISDB_T:
+		ret = tc90522_is_signal_locked_t(&tc90522_t_, &locked);
+		break;
+
+	case px4::SystemType::ISDB_S:
+		ret = tc90522_is_signal_locked_s(&tc90522_s_, &locked);
+		break;
+
+	default:
+		ret = -EINVAL;
+		break;
+	}
+
+	if (locked) {
+		dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::CheckLock(%u): system: %d locked: true\n", index_, current_system_);
+		lock_.unlock();
+		ret = SetCapture(true);
+		lock_.lock();
+	}
+
+	return ret;
+}
+
+int Isdb2056Device::Isdb2056Receiver::SetStreamId()
+{
+	if (current_system_ != px4::SystemType::ISDB_S)
+		return -EINVAL;
+
+	if (!init_ || !open_)
+		return -EINVAL;
+
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::SetStreamID(%u): tsid: %d\n", index_, params_.stream_id);
+
+	int ret = 0;
+	std::uint16_t tsid;
+	std::lock_guard<std::mutex> lock(lock_);
+
+	if (params_.stream_id < 8) {
+		for (int i = 50; i; i--) {
+			ret = tc90522_tmcc_get_tsid_s(&tc90522_s_, params_.stream_id, &tsid);
+			if ((!ret && tsid) || (ret == -EINVAL))
+				break;
+
+			Sleep(20);
+		}
+
+		if (ret)
+			return ret;
+
+		dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::SetStreamId(%u): slot: %u, tsid: 0x%04x\n", index_, params_.stream_id, tsid);
+	} else {
+		tsid = params_.stream_id;
+	}
+
+	ret = tc90522_set_tsid_s(&tc90522_s_, tsid);
+	if (ret)
+		return ret;
+
+	int i;
+
+	for (i = 50; i; i--) {
+		std::uint16_t tsid2;
+
+		ret = tc90522_get_tsid_s(&tc90522_s_, &tsid2);
+		if (!ret && tsid2 == tsid)
+			break;
+
+		Sleep(20);
+	}
+
+	if (!ret && !i)
+		ret = -EAGAIN;
+
+	return ret;
+}
+
+int Isdb2056Device::Isdb2056Receiver::SetLnbVoltage(std::int32_t voltage)
+{
+	if (!init_ || !open_)
+		return -EINVAL;
+
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::SetLnbVoltage(%u): voltage: %d\n", index_, voltage);
+
+	if (voltage != 0 && voltage != 15)
+		return -EINVAL;
+
+	return 0;
+}
+
+int Isdb2056Device::Isdb2056Receiver::SetCapture(bool capture)
+{
+	if (!init_ || !open_)
+		return -EINVAL;
+
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::SetCapture(%u): capture: %s\n", index_, (capture) ? "true" : "false");
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::SetCapture(%u): streaming: %s\n", index_, (streaming_) ? "true" : "false");
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::SetCapture(%u): current_system: %d\n", index_, current_system_);
+
+	int ret = 0;
+	std::lock_guard<std::mutex> lock(lock_);
+
+	switch (current_system_) {
+	case px4::SystemType::ISDB_T:
+		ret = tc90522_enable_ts_pins_t(&tc90522_t_, capture);
+		if (ret)
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::SetCapture(%u): tc90522_enable_ts_pins_t() failed.\n", index_);
+
+		break;
+
+	case px4::SystemType::ISDB_S:
+		ret = tc90522_enable_ts_pins_s(&tc90522_s_, capture);
+		if (ret)
+			dev_err(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::SetCapture(%u): tc90522_enable_ts_pins_s() failed.\n", index_);
+
+		break;
+
+	default:
+		return 0;
+	}
+
+	if (ret)
+		return ret;
+
+	if (capture) {
+		ret = parent_.PrepareCapture();
+		if (ret)
+			return ret;
+
+		ret = parent_.StartCapture();
+		if (ret)
+			return ret;
+
+		std::size_t size = 188 * parent_.config_.device.receiver_max_packets;
+
+		if (!streaming_) {
+			stream_buf_->Alloc(size);
+			stream_buf_->SetThresholdSize(size / 10);
+			stream_buf_->Start();
+			streaming_ = true;
+		} else {
+			stream_buf_->Purge();
+		}
+	} else {
+		ret = parent_.StopCapture();
+		if (ret)
+			return ret;
+
+		stream_buf_->Stop();
+		streaming_ = false;
+	}
+
+	dev_dbg(&parent_.dev_, "px4::Isdb2056Device::Isdb2056Receiver::SetCapture(%u): succeeded.\n", index_);
+
+	return ret;
+}
+
+int Isdb2056Device::Isdb2056Receiver::ReadStat(px4::command::StatType type, std::int32_t &value)
+{
+	if (!init_ || !open_)
+		return -EINVAL;
+
+	int ret = 0;
+	std::lock_guard<std::mutex> lock(lock_);
+
+	value = 0;
+
+	switch (type) {
+	case px4::command::StatType::SIGNAL_STRENGTH:
+		// not implemented
+		ret = -ENOSYS;
+		break;
+
+	case px4::command::StatType::CNR:
+		switch (current_system_) {
+		case px4::SystemType::ISDB_T:
+		{
+			std::uint32_t cndat;
+
+			ret = tc90522_get_cndat_t(&tc90522_t_, &cndat);
+			if (ret)
+				break;
+
+			if (!cndat)
+				break;
+
+			double p, cnr;
+
+			p = 10 * std::log10(5505024 / (double)cndat);
+			cnr = (0.024 * p * p * p * p) - (1.6 * p * p * p) + (39.8 * p * p) + (549.1 * p) + 3096.5;
+
+			if (!std::isnan(cnr))
+				value = static_cast<std::int32_t>(cnr);
+
+			break;
+		}
+
+		case px4::SystemType::ISDB_S:
+		{
+			std::uint16_t cn;
+
+			ret = tc90522_get_cn_s(&tc90522_s_, &cn);
+			if (ret)
+				break;
+
+			if (cn < 3000)
+				break;
+
+			double p, cnr;
+
+			p = std::sqrt(cn - 3000) / 64;
+			cnr = (-1634.6 * p * p * p * p * p) + (14341 * p * p * p * p) - (50259 * p * p * p) + (88977 * p * p) - (89565 * p) + 58857;
+
+			if (!std::isnan(cnr))
+				value = static_cast<std::int32_t>(cnr);
+
+			break;
+		}
+
+		default:
+			ret = -EINVAL;
+			break;
+		}
+
+		break;
+
+	default:
+		ret = -EINVAL;
+		break;
+	}
+
+	return ret;
+}
+
+} // namespace px4

--- a/winusb/src/DriverHost_PX4/isdb2056_device.hpp
+++ b/winusb/src/DriverHost_PX4/isdb2056_device.hpp
@@ -1,0 +1,157 @@
+// isdb2056_device.hpp
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <atomic>
+#include <string>
+#include <mutex>
+#include <condition_variable>
+
+#include "device_definition_set.hpp"
+#include "device_base.hpp"
+#include "receiver_base.hpp"
+#include "receiver_manager.hpp"
+#include "ringbuffer.hpp"
+
+#include "winusb_compat.h"
+
+#include "i2c_comm.h"
+#include "it930x.h"
+#include "itedtv_bus.h"
+#include "tc90522.h"
+#include "r850.h"
+#include "rt710.h"
+
+namespace px4 {
+
+#define ISDB2056_DEVICE_TS_SYNC_COUNT	4U
+#define ISDB2056_DEVICE_TS_SYNC_SIZE		(188U * ISDB2056_DEVICE_TS_SYNC_COUNT)
+
+enum class Isdb2056DeviceModel {
+	ISDB2056 = 0,
+	ISDB2056N,
+	PXM1UR,
+	OTHER,
+};
+
+struct Isdb2056DeviceConfig final {
+	Isdb2056DeviceConfig()
+		: usb{ 816, 816, 5, false },
+		device{ 2048, 2000, true }
+	{}
+	struct {
+		unsigned int xfer_packets;
+		unsigned int urb_max_packets;
+		unsigned int max_urbs;
+		bool no_raw_io;
+	} usb;
+	struct {
+		unsigned int receiver_max_packets;
+		int psb_purge_timeout;
+		bool discard_null_packets;
+	} device;
+};
+
+class Isdb2056Device final : public px4::DeviceBase {
+public:
+	Isdb2056Device() = delete;
+	Isdb2056Device(const std::wstring &path, const px4::DeviceDefinition &device_def, std::uintptr_t index, px4::ReceiverManager &receiver_manager);
+	~Isdb2056Device();
+
+	// cannot copy
+	Isdb2056Device(const Isdb2056Device &) = delete;
+	Isdb2056Device& operator=(const Isdb2056Device &) = delete;
+
+	// cannot move
+	Isdb2056Device(Isdb2056Device &&) = delete;
+	Isdb2056Device& operator=(Isdb2056Device &&) = delete;
+
+	int Init() override;
+	void Term() override;
+	void SetAvailability(bool available) override;
+	px4::ReceiverBase * GetReceiver(int id) const override;
+
+private:
+	struct StreamContext final {
+		std::shared_ptr<px4::ReceiverBase::StreamBuffer> stream_buf;
+		std::uint8_t remain_buf[ISDB2056_DEVICE_TS_SYNC_SIZE];
+		std::size_t remain_len;
+	};
+
+	class Isdb2056Receiver final : public px4::ReceiverBase {
+	public:
+		Isdb2056Receiver() = delete;
+		Isdb2056Receiver(Isdb2056Device &parent, std::uintptr_t index);
+		~Isdb2056Receiver();
+
+		// cannot copy
+		Isdb2056Receiver(const Isdb2056Receiver &) = delete;
+		Isdb2056Receiver& operator=(const Isdb2056Receiver &) = delete;
+
+		// cannot move
+		Isdb2056Receiver(Isdb2056Receiver &&) = delete;
+		Isdb2056Receiver& operator=(Isdb2056Receiver &&) = delete;
+
+		int Init(bool sleep);
+		void Term();
+
+		int Open() override;
+		void Close() override;
+		int CheckLock(bool &locked) override;
+		int SetLnbVoltage(std::int32_t voltage) override;
+		int SetCapture(bool capture) override;
+		int ReadStat(px4::command::StatType type, std::int32_t &value) override;
+
+	protected:
+		int SetFrequency() override;
+		int SetStreamId() override;
+
+	private:
+		static struct tc90522_regbuf tc_init_t_[];
+		static struct tc90522_regbuf tc_init_s_[];
+
+		Isdb2056Device &parent_;
+		std::uintptr_t index_;
+
+		std::mutex lock_;
+		std::atomic_bool init_;
+		std::atomic_bool open_;
+		std::condition_variable close_cond_;
+		bool lnb_power_;
+		tc90522_demod tc90522_t_;
+		tc90522_demod tc90522_s0_;
+		tc90522_demod tc90522_s_;
+		r850_tuner r850_;
+		rt710_tuner rt710_;
+		px4::SystemType current_system_;
+		std::atomic_bool streaming_;
+	};
+
+	void LoadConfig();
+
+	const i2c_comm_master& GetI2cMaster(int bus) const;
+
+	int SetBackendPower(bool state);
+	int SetLnbVoltage(std::int32_t voltage);
+
+	int PrepareCapture();
+	int StartCapture();
+	int StopCapture();
+
+	static void StreamProcess(std::shared_ptr<px4::ReceiverBase::StreamBuffer> stream_buf, std::uint8_t **buf, std::size_t &len);
+	static int StreamHandler(void *context, void *buf, std::uint32_t len);
+
+	Isdb2056DeviceModel model_;
+	Isdb2056DeviceConfig config_;
+	std::recursive_mutex lock_;
+	std::atomic_bool available_;
+	std::atomic_bool init_;
+	unsigned int streaming_count_;
+	std::unique_ptr<Isdb2056Receiver> receiver_;
+	it930x_bridge it930x_;
+	StreamContext stream_ctx_;
+};
+
+} // namespace px4

--- a/winusb/src/fwtool/fwtool.vcxproj
+++ b/winusb/src/fwtool/fwtool.vcxproj
@@ -9,7 +9,7 @@
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
-     <ProjectConfiguration Include="Release-static|Win32">
+    <ProjectConfiguration Include="Release-static|Win32">
       <Configuration>Release-static</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
@@ -36,14 +36,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
@@ -51,7 +51,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-static|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
@@ -59,14 +59,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
@@ -74,7 +74,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-static|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>


### PR DESCRIPTION
極めて有益な変更と思われることから、tsukumijima/px4_drv にもマージしたいです。

@hendecarows 勝手なメンションで申し訳ないのですが、よければ feature/isdb2056 ブランチでの変更意図についてご説明いただけないでしょうか。
- https://github.com/tsukumijima/px4_drv/commit/b3ec9051ac51663fce549f00ffedca4174e3ef1f : 私の手元にある ISDB2056N では tc90522_s0 の初期化処理を入れずとも動作しているが、なぜ追加する必要があるのか
    - 私は isdb2056n.sys のデコンパイル結果とのにらめっこしかやれてないのですが、usbpcap で傍受した Windows + 公式ドライバでの USB 通信内容を模倣した、とかでしょうか？
- https://github.com/tsukumijima/px4_drv/commit/8af1ed950a3d3f3969a3038f3e2257c53a8d82ba : コード自体は申し分ないが、どの機種でどの程度動作確認されているのか
    - PX-M1UR / ISDB2056 / ISDB2056N に対応されているようですが、m1ur_device.c と s1ur_device.c の差分からも分かる通り PX-S1UR は PX-M1UR から BS 用チューナーを取り除いた以外は PX-M1UR と共通設計なので、せっかくなら PX-S1UR にも対応させたいところではある…
        - 私も PX-S1UR の実機は持っていませんが、対応だけでもしておけば誰かが動作確認してくれるはず
    - ちなみに Linux 版 px4_drv で PX-M1UR / PX-S1UR のドライバ実装が ISDB2056/ISDB2056N と分かれている理由は、マージ元の https://github.com/techmadot/px4_drv でそうなっていたからに過ぎません
       - 特に m1ur_device.c はデバイス名以外は isdb2056_device.c とほとんど共通なため DRY の観点からは共通化したい
       - ただ私が C 言語に詳しくないこと、動作確認できている以上既存のコードを壊したくないことから、そのままになってしまっている