### PR TITLE
fix UBSAN false positive

### DIFF
--- a/driver/ptx_chrdev.c
+++ b/driver/ptx_chrdev.c
@@ -807,7 +807,7 @@ int ptx_chrdev_context_add_group(struct ptx_chrdev_context *chrdev_ctx,
 					    base, num,
 					    PTX_CHRDEV_MINOR_IN_USE);
 
-	group = kzalloc(sizeof(*group) + (sizeof(group->chrdev[0]) * (num - 1)),
+	group = kzalloc(sizeof(*group) + (sizeof(group->chrdev[0]) * num),
 			GFP_KERNEL);
 	if (!group) {
 		ret = -ENOMEM;

--- a/driver/ptx_chrdev.h
+++ b/driver/ptx_chrdev.h
@@ -100,7 +100,7 @@ struct ptx_chrdev_group {
 	void (*owner_kref_release)(struct kref *);
 	unsigned int minor_base;
 	unsigned int chrdev_num;
-	struct ptx_chrdev chrdev[1];
+	struct ptx_chrdev chrdev[];
 };
 
 #define PTX_CHRDEV_MINOR_FREE		0


### PR DESCRIPTION
https://gist.github.com/kounoike/8aff2232ac1e4ae6908d182137951246#file-gistfile1-txt-L1032

この辺のように何か所かdmesgに警告が出るので聞いたところotya氏によるとこれの影響らしい。
https://lore.kernel.org/all/20230517232801.never.262-kees@kernel.org/

無害ではあるもののdmesgに出てるとびっくりするので修正しておきたい。