### PR TITLE
add personal apt repository for pages

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -3,17 +3,15 @@ name: Build and Release Debian Package
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
-
   build_and_release:
     name: Build and Release Debian Package
     runs-on: ubuntu-20.04
     permissions:
       contents: write
     steps:
-
       - name: Checkout repository
         uses: actions/checkout@v3
 
@@ -29,3 +27,38 @@ jobs:
           generate_release_notes: true
           files: |
             ../*.deb
+
+  build_apt_repository:
+    name: Build Private APT repository GitHub Pages
+    runs-on: ubuntu-24.04
+    needs: build_and_release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: import gpg key
+        run: |
+          echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --import
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Build APT repository
+        run: |
+          ./make_apt_pages.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    needs: build_apt_repository
+    runs-on: ubuntu-24.04
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy pages
+        uses: actions/deploy-pages@v4

--- a/build_apt_pages.sh
+++ b/build_apt_pages.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+################################################################################################################
+# このスクリプトの使い方
+# 1. `gpg --full-gen-key` で鍵を作成
+#    - 鍵の種類は RSA 4096bit 推奨（良く分かってない）
+#    - 鍵の有効期限は 0（無期限）推奨
+#    - Real NameやEmailは適当（gmailな+の後ろを変えて別アドレスにしておいた方がいいかも）
+#    - パスフレーズは設定しない
+# 2. `gpg --export-secret-keys "example@example.com" | base64` でbase64形式にしてエクスポート
+# 3. 2でエクスポートしたキーをGitHubのActions SecretにGPG_PRIVATE_KEYとして登録
+# 4. `gpg --armor --export "example@example.com" > KEY.gpg` で公開鍵をエクスポートしてリポジトリルートに配置
+# 5. 設定したメールアドレスをこのスクリプトのGPG_EMAILに設定
+# 6. GitHubリポジトリの設定でPagesを有効にして、Actionsでのデプロイを選択
+################################################################################################################
+
+set -xe
+
+cd $(dirname $0)
+
+OUTDIR="./out"
+GPG_EMAIL="test@example.com"
+
+function get_debreleases() {
+    local repo=$1
+    local releases_json=$(gh release list -R ${repo} --limit 100 --json name,isDraft,isPrerelease)
+    local releases=$(echo "${releases_json}" | jq -r '.[] | select(.isDraft == false and .isPrerelease == false) | .name')
+    for rel in ${releases}; do
+        local assets_json=$(gh release view -R ${repo} "${rel}" --json assets)
+        local assets_url=$(echo "${assets_json}" | jq -r '.assets[] | select(.name | endswith(".deb")) | .url')
+        for url in ${assets_url}; do
+            if [ -z "${url}" ]; then
+                continue
+            fi
+            curl -sSL -o "${OUTDIR}/$(basename ${url})" "${url}"
+        done
+    done
+}
+
+function build_apt_repository() {
+    cd ${OUTDIR}
+    dpkg-scanpackages --multiversion . > Packages
+    gzip -k -f Packages
+
+    apt-ftparchive release . > Release
+    gpg --default-key "${GPG_EMAIL}" -abs -o - Release > Release.gpg
+    gpg --default-key "${GPG_EMAIL}" --clearsign -o - Release > InRelease
+}
+
+# main logic
+
+# mkdir
+[ ! -d "${OUTDIR}" ] && mkdir -p "${OUTDIR}"
+
+# public key
+
+cp -f KEY.gpg "${OUTDIR}/KEY.gpg"
+
+# tsukumijima/px4_drv
+get_debreleases tsukumijima/px4_drv
+
+# build apt repository
+build_apt_repository


### PR DESCRIPTION
APTリポジトリをpagesで提供する修正です。https://github.com/kounoike/dtv-ppa-test で動作確認はしましたが、このスクリプト自体を動作確認したわけではないのでミスが入ってるかもしれません。

とりあえずドキュメントは修正せずに一度リリースして動作確認した方がいいと思うのでまずはビルドスクリプトの追加だけで。

動作すれば、以下手順でインストール出来るようになるはずです

```bash
curl -s --compressed "https://tsukumijima.github.io/px4_drv/KEY.gpg" | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/px4_drv.gpg >/dev/null && \
 echo "deb [signed-by=/etc/apt/trusted.gpg.d/px4_drv.gpg] https://tsukumijima.github.io/px4_drv/ ./" | sudo tee /etc/apt/sources.list.d/px4_drv.list >/dev/null
```

```bash
sudo apt update && \
sudo apt install px4-drv-dkms
```
