### PR TITLE
ホストを24.04にして20.04のコンテナを使ってdebをビルド、dkms動作のチェック＆buildのみを行うPRワークフロー追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,13 @@
-name: Build and Release Debian Package
+name: Build and Check Debian Package
 
 on:
-  push:
-    tags:
-      - "*"
+  pull_request:
+    branches:
+      - develop
 
 jobs:
-  build_and_release:
-    name: Build and Release Debian Package
+  build:
+    name: Build and Check Debian Package
     runs-on: ubuntu-24.04
     container:
       image: ubuntu:20.04
@@ -42,10 +42,3 @@ jobs:
       - name: Check dkms result
         run: ls -l /lib/modules/*/updates/dkms/px4_drv.ko*
         shell: bash
-
-      - name: Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: |
-            ../*.deb


### PR DESCRIPTION
- https://tech.guitarrapc.com/entry/2025/04/02/235900 の方法を使ってactionsの20.04ランナーが使えなくなった問題に対処
- ついでにチェックを強化
    - コンテナ内でインストールしてみる
    - コンテナ内に適当なLinuxカーネルパッケージを入れてdkmsでモジュールがビルドされたことを確認
- 上記のチェックをPRでも実行する

ビルドチェックはPRでなくプッシュで実行した方がいいかもしれないですけど、そこはお好みでお任せします