### PR TITLE
新しいカーネルをインストールするとdkmsでモジュールがアンロードされてしまう問題の対策

### DIFF
--- a/dkms/post_install.sh
+++ b/dkms/post_install.sh
@@ -1,11 +1,5 @@
 #!/bin/sh
 
-# Unload previous driver
-KVER=`uname -r`
-if [ `grep -e '^px4_drv' /proc/modules | wc -l` -ne 0 ]; then
-    modprobe -r px4_drv
-fi
-
 rm -fv /etc/udev/rules.d/90-px4.rules
 install -D -v -m 644 ./etc/99-px4video.rules /etc/udev/rules.d/99-px4video.rules
 install -D -v -m 644 ./etc/it930x-firmware.bin /lib/firmware/it930x-firmware.bin

--- a/dkms/post_remove.sh
+++ b/dkms/post_remove.sh
@@ -1,11 +1,5 @@
 #!/bin/sh
 
-# Unload previous driver
-KVER=`uname -r`
-if [ `grep -e '^px4_drv' /proc/modules | wc -l` -ne 0 ]; then
-    modprobe -r px4_drv
-fi
-
 if [ `find /lib/modules/ -name px4_drv.ko | wc -l` -eq 0 ]; then
     rm -fv /etc/udev/rules.d/90-px4.rules /etc/udev/rules.d/99-px4video.rules
     rm -fv /lib/firmware/it930x-firmware.bin


### PR DESCRIPTION
詳細は https://gist.github.com/kounoike/ac56d844dd02ac7718223eb407ca9c43

dkms/post_install.sh と post_remove.sh  で `modprobe -r px4_drv` しているため、モジュールがアンロードされてしまう。
dkmsはdebパッケージインストール直後の一回を除けば実行中のカーネルとは別のバージョンのLinuxカーネルをビルドしているときの処理ので、現在実行中のカーネルモジュールをアンロードするような処理は不要なので、削除してよい。

出来れば.debインストール直後から使える＆アンインストール時にドライバアンロードされるようにしたいが、
そのためには.debの方のpostinst/prermスクリプトに書かなければならない。
現在の `dkms mkdeb` コマンドだとそこまで細かな調整が多分効かないので妥協した方が良さそう。