### PR TITLE
Ubuntu 24.04環境でdkms後処理スクリプトが本来削除すべきではない99-px4video.rulesとit930x-firmware.binを削除してしまう問題を修正

### DIFF
--- a/dkms/post_remove.sh
+++ b/dkms/post_remove.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ `find /lib/modules/ -name px4_drv.ko | wc -l` -eq 0 ]; then
+if [ `find /lib/modules/ -name 'px4_drv.ko*' | wc -l` -eq 0 ]; then
     rm -fv /etc/udev/rules.d/90-px4.rules /etc/udev/rules.d/99-px4video.rules
     rm -fv /lib/firmware/it930x-firmware.bin
 fi

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -61,7 +61,7 @@ uninstall:
 	modprobe -r px4_drv; \
 	fi
 	$(cmd_prefix)rm -fv $(INSTALL_DIR)/px4_drv.ko
-	$(cmd_prefix)if [ `find /lib/modules/ -name px4_drv.ko | wc -l` -eq 0 ]; then \
+	$(cmd_prefix)if [ `find /lib/modules/ -name 'px4_drv.ko*' | wc -l` -eq 0 ]; then \
 	rm -fv /etc/udev/rules.d/90-px4.rules /etc/udev/rules.d/99-px4video.rules; \
 	fi
 	$(cmd_prefix)depmod -a $(KVER)


### PR DESCRIPTION
Ubuntu 24.04 LTS 環境は手元にはありませんが、良さげなので取り込みます。