### PR TITLE
moduleの書き方を変更することで、Errorを回避する

### DIFF
--- a/driver/driver_module.c
+++ b/driver/driver_module.c
@@ -10,12 +10,17 @@
 
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/version.h>
 
 #include "revision.h"
 #include "px4_usb.h"
 #include "firmware.h"
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,4)
 static int m_init(void)
+#else
+int init_module(void)
+#endif
 {
 	int ret = 0;
 
@@ -47,14 +52,19 @@ static int m_init(void)
 	return 0;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,4)
 static void m_cleanup(void)
+#else
+void cleanup_module(void)
+#endif
 {
 	px4_usb_unregister();
 }
 
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,4)
 module_init(m_init);
 module_exit(m_cleanup);
+#endif
 
 MODULE_VERSION(PX4_DRV_VERSION);
 MODULE_AUTHOR("nns779");

--- a/driver/driver_module.c
+++ b/driver/driver_module.c
@@ -15,7 +15,7 @@
 #include "px4_usb.h"
 #include "firmware.h"
 
-int init_module(void)
+static int m_init(void)
 {
 	int ret = 0;
 
@@ -47,10 +47,14 @@ int init_module(void)
 	return 0;
 }
 
-void cleanup_module(void)
+static void m_cleanup(void)
 {
 	px4_usb_unregister();
 }
+
+
+module_init(m_init);
+module_exit(m_cleanup);
 
 MODULE_VERSION(PX4_DRV_VERSION);
 MODULE_AUTHOR("nns779");


### PR DESCRIPTION
driver/driver_module.cの書き方を新しい書き方に少し変更したところ、エラーなくコンパイルすることができました。
これでIBT関連も大丈夫だと思いますので、プルリクエストさせていただきます。


closes #32 