### PR TITLE
driver: `__init` と `__exit` を指定

### DIFF
--- a/driver/driver_module.c
+++ b/driver/driver_module.c
@@ -17,7 +17,7 @@
 #include "firmware.h"
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,4)
-static int m_init(void)
+static int __init m_init(void)
 #else
 int init_module(void)
 #endif
@@ -53,7 +53,7 @@ int init_module(void)
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,4)
-static void m_cleanup(void)
+static void __exit m_cleanup(void)
 #else
 void cleanup_module(void)
 #endif


### PR DESCRIPTION
モジュールの初期化および終了関数にそれぞれ `__init` と `__exit` を指定した．これらマクロを使用していなくても大きな問題は発生しないと考えられるが，一般的な作法として追加した．

これらマクロの説明は以下を参照:

* https://tldp.org/LDP/lkmpg/2.4/html/x281.htm
* https://fastbitlab.com/linux-device-driver-programming-lecture-18-__init-and-__exit-macros/
* https://shnoh171.github.io/linux%20kernel/2019/09/01/linux-kernel-module-basics.html

### ビルド確認

`archlinx`イメージを使用

```console
$ docker run --rm -it -v $(pwd):/px4_drv archlinux
[root@1245c254444d px4_drv]# uname -a
Linux 1245c254444d 6.15.7-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 17 Jul 2025 21:05:29 +0000 x86_64 GNU/Linux
```

以下を実行

```shell
pacman -Sy --noconfirm dkms gcc linux-headers make
cp -a ./ /usr/src/px4_drv-0.5.4
dkms add px4_drv/0.5.4
dkms install px4_drv/0.5.4
find /lib/modules -name px4_drv.ko
```

### TODO

ビルド時に以下のメッセージが表示される．

```
Deprecated feature: CLEAN (/var/lib/dkms/px4_drv/0.5.4/source/dkms.conf)
```

以下の修正で`CLEAN`はdkmsから削除された:

* https://github.com/dell/dkms/commit/754f26f93a50348422d991ed9ce2fe9789a65583


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタ**
  * 新しいカーネルバージョン（6.15.4以降）に対応するため、初期化およびクリーンアップ処理の内部実装を調整しました。動作や機能には変更ありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->