### PR TITLE
kernel6.19系でのコンパイルエラーを修正

### DIFF
--- a/driver/px4_usb.c
+++ b/driver/px4_usb.c
@@ -382,7 +382,7 @@ static struct usb_driver px4_usb_driver = {
 	.id_table = px4_usb_ids
 };
 
-int px4_usb_register()
+int px4_usb_register(void)
 {
 	int ret = 0;
 
@@ -497,7 +497,7 @@ fail:
 	return ret;
 }
 
-void px4_usb_unregister()
+void px4_usb_unregister(void)
 {
 	usb_deregister(&px4_usb_driver);
 	ptx_chrdev_context_destroy(px4_usb_chrdev_ctx[ISDBT2071_USB_DEVICE]);

--- a/driver/px4_usb.c
+++ b/driver/px4_usb.c
@@ -16,6 +16,7 @@
 #include <linux/module.h>
 #include <linux/device.h>
 #include <linux/usb.h>
+#include <linux/version.h>
 
 #include "px4_usb_params.h"
 #include "px4_device_params.h"
@@ -382,7 +383,11 @@ static struct usb_driver px4_usb_driver = {
 	.id_table = px4_usb_ids
 };
 
-int px4_usb_register(void)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,19,0)
+	int px4_usb_register(void)
+#else
+	int px4_usb_register()
+#endif
 {
 	int ret = 0;
 
@@ -497,7 +502,11 @@ fail:
 	return ret;
 }
 
-void px4_usb_unregister(void)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,19,0)
+	void px4_usb_unregister(void)
+#else
+	void px4_usb_unregister()
+#endif
 {
 	usb_deregister(&px4_usb_driver);
 	ptx_chrdev_context_destroy(px4_usb_chrdev_ctx[ISDBT2071_USB_DEVICE]);


### PR DESCRIPTION
(引数なし関数で引数の型にvoidを指定する必要があるため横展開が必要かも)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Style**
  * USB ドライバの公開インターフェース表記を条件付きで更新し、最新カーネルとの互換性を向上しました。内部の振る舞いやユーザー向け機能に変更はなく、動作影響はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->