### PR TITLE
px4_device_params.cでmode値の範囲指定が誤っているのを修正

### DIFF
--- a/driver/px4_device_params.c
+++ b/driver/px4_device_params.c
@@ -55,7 +55,7 @@ static int get_multi_device_power_control_mode(char *buffer,
 {
 	enum px4_mldev_mode mode = px4_device_params.multi_device_power_control_mode;
 
-	if (mode < PX4_MLDEV_ALL_MODE && mode > PX4_MLDEV_S1_ONLY_MODE)
+	if (mode < PX4_MLDEV_ALL_MODE || mode > PX4_MLDEV_S1_ONLY_MODE)
 		return -EINVAL;
 
 	return scnprintf(buffer, 4096, "%s\n", mldev_mode_table[mode].str);


### PR DESCRIPTION
```
PX4_MLDEV_ALL_MODE=0
PX4_MLDEV_S1_ONLY_MODE=3
```
の認識で、この範囲の外にあるものをEINVALで返したいのであれば、符号が異なる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* マルチデバイス電源制御パラメータの検証ロジックを改善しました。無効な値がより正確に識別されるようになり、システムの安定性と信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->